### PR TITLE
added refresh tokens

### DIFF
--- a/foe_front/src/App.js
+++ b/foe_front/src/App.js
@@ -39,6 +39,34 @@ class App extends React.Component {
     }
   }
 
+  componentWillMount() {
+    window.addEventListener('storage', this.syncLogout)
+    this.refresh(this)
+  }
+
+  syncLogout = () => {
+    axios.defaults.headers.common["Authorization"] = ''
+      this.setState({
+        ...this.state,
+        currentUser: {},
+      })
+  }
+
+  async refresh(Application) {
+    try {
+      const response = await axios.get('/api/users/refresh')
+      axios.defaults.headers.common["Authorization"] = `Bearer ${response.data.token}`
+      Application.setState({
+        ...Application.state,
+        currentUser: response.data.user,
+      })
+      setTimeout(Application.refresh, 270000, Application) // token is good for 5 minutes - refresh every 4 minutes, 30 seconds
+    } catch (error) {
+      Application.syncLogout()
+      console.log("failed to refresh session -", error.message)
+    }
+  }
+
   render() {
     return (
       <Router>

--- a/foe_front/src/components/auth/Login.js
+++ b/foe_front/src/components/auth/Login.js
@@ -28,6 +28,7 @@ class Login extends React.Component {
                 ...this.state.Application.state,
                 currentUser: response.data.user,
             })
+            setTimeout(this.state.Application.refresh, 27000, this.state.Application)
         } catch (error) {
             console.log("Failed to login -", error.message)
         }

--- a/foe_front/src/components/auth/Logout.js
+++ b/foe_front/src/components/auth/Logout.js
@@ -1,21 +1,32 @@
-import React, { useEffect } from "react"
+import React, { useEffect, useState } from "react"
 
 const axios = require("axios").default
 
 function Logout(props) {
+    const [state, setState] = useState({
+        loading: true
+    })
 
     useEffect(() => {
-        props.Application.setState({
-            ...props.Application.state,
-            currentUser: {}
-        })
-        axios.defaults.headers.common["Authorization"] = ""
+        async function apiLogout() {
+            await axios.get('/api/users/logout')
+            setState({
+                loading: false
+            })
+            props.Application.syncLogout()
+            localStorage.setItem('logout', Date.now())
+        }
+        apiLogout()
     }, [])
 
     
     return (
         <div className="main">
-            Successfully logged out!
+            {state.loading ? 
+                "Logging out..."
+            :
+                "Successfully logged out!"
+            }
         </div>
     )
 }

--- a/foe_front/src/components/auth/Register.js
+++ b/foe_front/src/components/auth/Register.js
@@ -35,6 +35,7 @@ class Register extends React.Component {
                 ...this.state.Application.state,
                 currentUser: response.data.user,
             })
+            setTimeout(this.state.Application.refresh, 27000, this.state.Application)
         } catch (error) {
             console.log("Failed to register -", error.message)
         }


### PR DESCRIPTION
Requires backend branch of same name.

Utilizes refresh tokens to maintain the user session. App automatically sends a request to /users/refresh on load and every 4 min 30 sec to get a new access token.

Utilizes localstorage to handle syncing logout if multiple tabs are open at once.

Logging in will last one day or until the logout button is hit, all tabs should log out together if logout is hit. Refreshing the page will log you in if the refresh token is still valid.