### PR TITLE
altered route structure of campaign and world components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,8 @@
     "rules": {
         "react/prop-types": "off",
         "no-console": "warn",
-        "max-len": ["error", { "code": 127 }]
+        "max-len": ["error", { "code": 127 }],
+        "semi": "error"
     },
     "env": {
         "amd": true,

--- a/src/App.js
+++ b/src/App.js
@@ -6,12 +6,10 @@ import {
 } from "react-router-dom";
 import "./staticfiles/App.css";
 
-import Campaign from "./components/intel/Campaign";
+import CampaignSelector from "./components/intel/CampaignSelector";
 import NewCampaign from "./components/intel/NewCampaign";
 import PinHistory from "./components/intel/PinHistory";
 import NewPin from "./components/intel/NewPin";
-import World from "./components/intel/World";
-import NewWorld from "./components/intel/NewWorld";
 
 import Login from "./components/auth/Login";
 import Logout from "./components/auth/Logout";
@@ -87,12 +85,11 @@ class App extends React.Component {
                 /*end if user is admin*/}
                 {this.state.currentUser.discord_confirmed ? //if user has confirmed their discord
                   <Switch>
-                    <Route exact path="/campaign/new" render={props => <NewCampaign {...props} Application={this} />} />
-                    <Route exact path="/campaign/:id" render={props => <Campaign {...props} Application={this} />} />
+                    <Route exact path="/campaigns/new" render={props => <NewCampaign {...props} Application={this} />} />
+                    <Route path="/campaigns/:campaign" render={props => <CampaignSelector {...props} Application={this} />} />
+                    <Route path="/campaigns" render={props => <CampaignSelector {...props} Application={this} />} />
                     <Route exact path="/pin/new" render={props => <NewPin {...props} Application={this} />} />
                     <Route exact path="/pin/:id" render={props => <PinHistory {...props} Application={this} />} />
-                    <Route exact path="/world/new" render={props => <NewWorld {...props} Application={this} />} />
-                    <Route exact path="/world/:id" render={props => <World {...props} Application={this} />} />
                     <Route path="/" render={props => <Home {...props} Application={this} />} />
                   </Switch>
                 : // else user has not confirmed their discord

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,12 +1,17 @@
-import React from 'react';
-import CampaignSelector from './intel/CampaignSelector.js';
+import React, { useEffect } from 'react';
 
-function Home() {
+import { Link } from "react-router-dom";
 
+function Home(props) {
+
+    useEffect(() => {
+        props.history.push('/campaigns');
+    },[]);
+    
     
     return(
         <div>
-            <CampaignSelector/>
+            <Link to="/campaigns">Campaign Maps</Link>
         </div>
     );
 }

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 
 import swal from "sweetalert";
 
-import validatePassword from "../helper_functions/ValidatePassword"
+import validatePassword from "../helper_functions/ValidatePassword";
 
 const axios = require('axios').default;
 
@@ -11,7 +11,7 @@ function EditProfile(props) {
     const [state, setState] = useState({
         password1: "",
         password2: "",
-    })
+    });
 
     const handleSelect = async (event) => {
         let user = props.Application.state.currentUser;
@@ -32,7 +32,7 @@ function EditProfile(props) {
             swal("Error", "Passwords don't match.", "error");
             return;
         }
-        let errors = validatePassword(state.password1)
+        let errors = validatePassword(state.password1);
         if (errors.length > 0) {
             swal("Error", errors.join('\n'), "error");
             return;
@@ -42,17 +42,17 @@ function EditProfile(props) {
             await axios.patch(`/api/users/${user.id}`, JSON.stringify({
                 'theme': user.theme,
                 'password': state.password1,
-            }))
+            }));
             swal("Success", "Password updated!", "success");
         } catch (error) {
             swal("Error", error.response.data, "error");
         }
-    }
+    };
 
     const handleChange = async (event) => setState({
         ...state,
         [event.target.name]: event.target.value,
-    })
+    });
 
 
     return (

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -17,8 +17,7 @@ function Sidebar(props) {
                 {props.Application.state.currentUser.role === "admin" ? // if user is admin
                 <div>
                     <br /><Link to="/admin">Admin</Link>
-                    <br /><Link to='/campaign/new'>Add Campaign</Link>
-                    <br /><Link to='/world/new'>Add World</Link>
+                    <br /><Link to='/campaigns/new'>Add Campaign</Link>
                 </div>
                 : // else
                     ""

--- a/src/components/admin/GuildList.js
+++ b/src/components/admin/GuildList.js
@@ -34,7 +34,7 @@ class GuildList extends React.Component {
                 ...this.state,
                 guilds: [...this.state.guilds, response.data]
             });
-            swal("Success", `${this.state.guildName} created!`, "success")
+            swal("Success", `${this.state.guildName} created!`, "success");
         } catch (error) {
             if (error.response.data.includes(`(name)=(${this.state.guildName}) already exists`)) {
                 swal("Error", `Guild with name '${this.state.guildName}' already exists.`, "error");

--- a/src/components/admin/UpdateUser.js
+++ b/src/components/admin/UpdateUser.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import swal from "sweetalert";
 
-import validatePassword from "../../helper_functions/ValidatePassword"
+import validatePassword from "../../helper_functions/ValidatePassword";
 
 const axios = require("axios").default;
 
@@ -59,7 +59,7 @@ class Admin extends React.Component {
             this.setState({
                 ...this.state,
                 user: putResponse.data,
-            })
+            });
             const getResponse = await axios.get('/api/guilds');
             this.state.adminPanel.setState({
                 ...this.state.adminPanel.state,
@@ -75,7 +75,7 @@ class Admin extends React.Component {
         let errors = validatePassword(this.state.password);
         if (errors.length > 0) {
             swal("Error", errors.join('\n'), "error");
-            return
+            return;
         }
         try {
             await axios.put(`/api/users/${this.state.id}`, JSON.stringify({
@@ -83,7 +83,7 @@ class Admin extends React.Component {
                 role: this.state.user.role,
                 is_active: this.state.user.is_active,
                 guild_id: this.state.user.guild.id,
-            }))
+            }));
             swal("Success", "Password updated.", "success");
         } catch (error) {
             swal("Error", error.response.data, "error");

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import swal from "sweetalert";
 
-import validatePassword from "../../helper_functions/ValidatePassword"
+import validatePassword from "../../helper_functions/ValidatePassword";
 
 const axios = require("axios").default;
 
@@ -42,10 +42,10 @@ class Register extends React.Component {
             swal("Error", "Passwords don't match.", "error");
             return;
         }
-        let errors = validatePassword(this.state.password1)
+        let errors = validatePassword(this.state.password1);
         if (errors.length > 0) {
             swal("Error", errors.join('\n'), "error");
-            return
+            return;
         }
         try {
             const response = await axios.post("/api/users", JSON.stringify({
@@ -61,7 +61,7 @@ class Register extends React.Component {
             setTimeout(this.state.Application.refresh, 27000, this.state.Application);
         } catch (error) {
             if (error.response.data.includes(`(${this.state.username}) already exists`)) {
-                swal("Error", "Username already taken, please try another.", "error")
+                swal("Error", "Username already taken, please try another.", "error");
                 return;
             }
             swal("Error", error.response.data, "error");

--- a/src/components/intel/Campaign.js
+++ b/src/components/intel/Campaign.js
@@ -1,47 +1,59 @@
-import React from "react";
-import World from './World.js';
+import React, {
+    useEffect,
+    useState,
+} from "react";
 
-class Campaign extends React.Component {
-    constructor(props) {
-        super();
-        this.state = {
-            campaign: props.campaign,
-            loaded: false
-        };
-    }
+import { Link } from "react-router-dom";
+import swal from "sweetalert";
 
-    componentDidUpdate(prevProps) {
-        if (this.props.campaign !== prevProps.campaign) {
-            this.setState({
-                ...this.state,
-                campaign:this.props.campaign,
-                loaded:true,
-            });
+const axios = require("axios").default;
+
+
+function Campaign(props) {
+
+    const [state, setState] = useState({
+        campaign: {name: "", worlds: []}
+    });
+
+    useEffect(() => {
+        let campaignName = props.match.params.campaign;
+        async function fetchData() {
+            try {
+                const response = await axios.get(`/api/campaigns/q?name=${campaignName}`);
+                setState({
+                    ...state,
+                    campaign: response.data,
+                });
+            } catch (error) {
+                if (error.response.data.includes(`404 Not Found`)) {
+                    swal("Error", `Campaign with name '${campaignName}' not found.`, "error");
+                    props.history.push('/campaigns');
+                    return;
+                }
+                swal("Error", error.response.data, "error");
+                props.history.push('/campaigns');
+            }
         }
-    }
+        fetchData();
+    }, [props.match.params.campaign]);
 
-    content() {
-        return(
-            <div>
-            <p className='banner'>{this.state.campaign.name}</p>
-            <p>The campaign ID is {this.state.campaign.id}</p>
-            <img src={this.state.campaign.image} className='campaign' alt='Faled to Load Campaign'/>
-            {this.state.loaded ? this.state.campaign.worlds.map( (world) => (
-            <World key={world.id}
-                    id={world.id}
-                    world={world}/>
-            )): null}
+
+    return(
+        <div>
+            <p className='banner'>{state.campaign.name}</p>
+            <img src={state.campaign.image} className='campaign' alt='Failed to Load Campaign'/>
+            <br />
+            {state.campaign.worlds.map(world => 
+                    <div key={world}>
+                        <Link to={`/campaigns/${state.campaign.name}/${world.name}`} >{world.name}</Link><br />
+                    </div>
+                )}
+            {props.Application.state.currentUser.role === "admin" ? // if user is admin
+                <Link to={`/campaigns/${state.campaign.name}/addworld`}>Add World</Link>
+            : // else
+                "" /* end if user is admin */}
         </div>
-        );
-    }
-
-    render() {
-        return(
-            <div>
-            {this.state.campaign ? this.content(): null}
-            </div>
-        );
-    }
+    );
 }
 
 export default Campaign;

--- a/src/components/intel/NewCampaign.js
+++ b/src/components/intel/NewCampaign.js
@@ -38,6 +38,10 @@ class NewCampaign extends React.Component {
             await axios.post("/api/campaigns", formData, config);
             swal("Success", "Campaign posted!", "success");
         } catch (error) {
+            if (error.response.data.includes('violates unique constraint "campaigns_image_key"')) {
+                swal("Error", "A file with that name has already been uploaded.", "error");
+                return;
+            }
             swal("Error", error.response.data, "error");
         }
     }

--- a/src/components/intel/NewWorld.js
+++ b/src/components/intel/NewWorld.js
@@ -11,7 +11,6 @@ class NewWorld extends React.Component {
             Application: props.Application,
             name: "",
             file: null,
-            campaign_id: 0,
             filename: "choose a file",
         };
     }
@@ -43,7 +42,7 @@ class NewWorld extends React.Component {
         const formData = new FormData();
         formData.append("file", this.state.file, this.state.file.name);
         formData.append("name", this.state.name);
-        formData.append("campaign_id", this.state.campaign_id);
+        formData.append("campaign_id", this.props.campaign.id);
         try {
             let config = { headers: {
                 "Content-Type": "multipart/form-data"
@@ -51,10 +50,6 @@ class NewWorld extends React.Component {
             await axios.post("/api/worlds", formData, config);
             swal("Success", "World created!", "success");
         } catch (error) {
-            if (error.response.data.includes(`(campaign_id)=(${this.state.campaign_id}) is not present`)) {
-                swal("Error", `Campaign with id '${this.state.campaign_id}' not found.`, "error");
-                return;
-            }
             swal("Error", error.response.data, "error");
         }
     }
@@ -63,8 +58,10 @@ class NewWorld extends React.Component {
     render() {
         return (
             <div>
+                <br />
+                <br />
+                <p>Add world to {this.props.campaign.name}</p>
                 <input type="text" name="name" placeholder='World Name' onChange={this.handleChange}/>
-                <input type="number" name="campaign_id" placeholder='campaign id' onChange={this.handleChange}/>
                 <input type="file" name="file" id="file" onChange={this.handleSelect}/>
                 <label htmlFor="file">{this.state.filename}</label>
                 <button onClick={this.handleSubmit}>Submit</button>

--- a/src/components/intel/World.js
+++ b/src/components/intel/World.js
@@ -2,16 +2,28 @@ import React from "react";
 import Pin from './Pin.js';
 import NewPin from './NewPin.js';
 
+const axios = require('axios').default;
+
 class World extends React.Component {
-    constructor(props) {
+    constructor() {
         super();
         this.reloadPins = this.reloadPins.bind(this);
         this.cancelPin = this.cancelPin.bind(this);
         this.state = {
-            world: props.world,
+            world: {pins: []},
             newPin: false,
             newPinPosition: [0,0]
         };
+    }
+
+    async componentDidMount() {
+        let campaignName = this.props.match.params.campaign;
+        let worldName = this.props.match.params.world;
+        const response = await axios.get(`/api/worlds/q?campaign=${campaignName}&world=${worldName}`);
+        this.setState({
+            ...this.state,
+            world: response.data,
+        });
     }
 
     addNewPin = (e) => {

--- a/src/helper_functions/ValidatePassword.js
+++ b/src/helper_functions/ValidatePassword.js
@@ -1,21 +1,21 @@
 function validatePassword(password) {
-    let errors = []
+    let errors = [];
     if (password.length < 8) {
-        errors.push("Password must be at least 8 characters.")
+        errors.push("Password must be at least 8 characters.");
     }
     if (password === password.toUpperCase()) {
-        errors.push("Password must contain at least 1 lowercase character.")
+        errors.push("Password must contain at least 1 lowercase character.");
     }
     if (password === password.toLowerCase()) {
-        errors.push("Password must contain at least 1 uppercase character.")
+        errors.push("Password must contain at least 1 uppercase character.");
     }
     if (!/\d/.test(password)) {
-        errors.push("Password must contain at least 1 number.")
+        errors.push("Password must contain at least 1 number.");
     }
     if (!/\W/.test(password)) {
-        errors.push("Password must contain at least 1 special character.")
+        errors.push("Password must contain at least 1 special character.");
     }
-    return errors
+    return errors;
 }
 
-export default validatePassword
+export default validatePassword;


### PR DESCRIPTION
Restructured the routes for the campaign components. 

Home no longer has the campaign selector, it simply redirects to /campaigns which is where the selector is. 

The selector should automatically grab the first campaign and redirect to /campaigns/campaignname where you can see the campaign.

On that page there should be links to any world components that belong to that campaign, and if you are logged in as an administrator, a link to add a world to that campaign.

The campaign and world pages no longer get data as a prop but instead communicate with the backend. This does mean more traffic, I plan on eventually replacing this system with a websocket connection.

Since adding a world is now tied to the specific campaign on its own, you don't have a field to input an id.

Also, noticed I forgot to keep the semicolon rule in linting, added it back in and caught several spots that were missing it. 