### PR TITLE
added functionality to click on the world in the campaign image as a link

### DIFF
--- a/src/components/intel/Campaign.js
+++ b/src/components/intel/Campaign.js
@@ -1,20 +1,53 @@
-import React from "react";
-
+import React, { useEffect, useState } from "react";
+import { CircleMarker, MapContainer, ImageOverlay } from 'react-leaflet';
+import { CRS } from "leaflet";
 import { Link } from "react-router-dom";
 
 
 function Campaign(props) {
+    const [state, setState] = useState({
+        width: 0,
+        height: 0,
+        loading: true
+    });
 
+    useEffect(() => {
+        if (props.campaign.image == undefined) {return;}
+        const image = new Image();
+        image.src = props.campaign.image;
+        image.onload = () => setState({width: image.naturalWidth, height: image.naturalHeight, loading: false});
+    },[props.campaign]);
+
+    if (state.loading) {return null;}
     return(
         <div>
             <p className='banner'>{props.campaign.name}</p>
-            <img src={props.campaign.image} className='campaign' alt='Failed to Load Campaign'/>
-            <br />
-            {props.campaign.worlds.map(world => 
-                    <div key={world}>
-                        <Link to={`/campaigns/${props.campaign.name}/${world.name}`} >{world.name}</Link><br />
-                    </div>
+            <MapContainer center={[0, 0]}
+                          keyboard={false}
+                          zoom={-1}
+                          scrollWheelZoom={false}
+                          crs={CRS.Simple}
+                          minZoom={-1}
+                          maxZoom={-1}
+                          dragging={false}
+                          zoomControl={false}
+            >
+                <ImageOverlay url={props.campaign.image}
+                              bounds={[[-1 * state.height, -1 * state.width], [state.height, state.width]]} />
+                {props.campaign.worlds.map(world => 
+                        <div key={world}>
+                            <CircleMarker
+                            center={[world.center_lat, world.center_lng]}
+                            radius={world.radius}
+                            opacity={0}
+                            fillOpacity={0}
+                            eventHandlers={{click: () => 
+                                props.history.push(`/campaigns/${props.campaign.name}/${world.name}`)
+                            }} />
+                        </div>
                 )}
+            </MapContainer>
+            <br />
             {props.Application.state.currentUser.role === "admin" ? // if user is admin
                 <Link to={`/campaigns/${props.campaign.name}/addworld`}>Add World</Link>
             : // else

--- a/src/components/intel/NewWorld.js
+++ b/src/components/intel/NewWorld.js
@@ -1,85 +1,119 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { MapContainer, ImageOverlay } from 'react-leaflet';
+import { CRS } from "leaflet";
 
 import swal from "sweetalert";
 
 import Socket from "../../helper_functions/Socket";
+import WorldLinkDrawer from "./WorldLinkDrawer";
 
 const axios = require("axios").default;
 
-class NewWorld extends React.Component {
-    constructor(props) {
-        super();
-        this.state = {
-            Application: props.Application,
-            name: "",
-            file: null,
-            filename: "choose a file",
+const socket = new Socket();
+
+function NewWorld(props) {
+    const [state, setState] = useState({
+        Application: props.Application,
+        name: "",
+        file: null,
+        filename: "choose a file",
+        centerLat: 0,
+        centerLng: 0,
+        radius: 0,
+        height: 0,
+        width: 0,
+        loading: true
+    });
+
+    useEffect(() => {
+        socket.connect();
+        return () => {
+            socket.disconnect();
         };
-        this.socket = new Socket();
-    }
+    },[]);
 
-    componentDidMount() {
-        this.socket.connect();
-    }
+    useEffect(() => {
+        if (props.campaign.image == undefined) {return;}
+        const image = new Image();
+        image.src = props.campaign.image;
+        image.onload = () => setState({...state, width: image.naturalWidth, height: image.naturalHeight, loading: false});
+    },[props.campaign]);
 
-    componentWillUnmount() {
-        this.socket.disconnect();
-    }
-
-    handleChange = (event) => this.setState({
-        ...this.state,
+    const handleChange = (event) => setState({
+        ...state,
         [event.target.name]: event.target.value,
     });
 
-    handleSelect = (event) => this.setState({
-        ...this.state,
+    const handleSelect = (event) => setState({
+        ...state,
         [event.target.name]: event.target.files[0],
         filename: event.target.value.split('\\').pop()
     });
 
-    handleSubmit = async () => {
-        if (this.state.name === "") {
+    const handleSubmit = async () => {
+        if (state.name === "") {
             swal("Error", "Please enter the name of the world.", "error");
             return;
         }
-        if (this.state.campaign_id < 1) {
+        if (state.campaign_id < 1) {
             swal("Error", "Please enter the campaign id.", "error");
             return;
         }
-        if (this.state.file === null) {
+        if (state.file === null) {
             swal("Error", "Please upload a file.", "error");
             return;
         }
+        if (state.radius === 0) {
+            swal("Error", "Please draw the click area on the map.", "error");
+            return;
+        }
         const formData = new FormData();
-        formData.append("file", this.state.file, this.state.file.name);
-        formData.append("name", this.state.name);
-        formData.append("campaign_id", this.props.campaign.id);
+        formData.append("file", state.file, state.file.name);
+        formData.append("name", state.name);
+        formData.append("campaign_id", props.campaign.id);
+        formData.append("center_lat", state.centerLat);
+        formData.append("center_lng", state.centerLng);
+        formData.append("radius", state.radius);
         try {
             let config = { headers: {
                 "Content-Type": "multipart/form-data"
             } };
             await axios.post("/api/worlds", formData, config);
-            this.socket.send('campaign-update');
+            socket.send('campaign-update');
             swal("Success", "World created!", "success");
         } catch (error) {
             swal("Error", error.response.data, "error");
         }
-    }
+    };
 
-    
-    render() {
-        return (
-            <div>
-                <br />
-                <br />
-                <p>Add world to {this.props.campaign.name}</p>
-                <input type="text" name="name" placeholder='World Name' onChange={this.handleChange}/>
-                <input type="file" name="file" id="file" onChange={this.handleSelect}/>
-                <label htmlFor="file">{this.state.filename}</label>
-                <button onClick={this.handleSubmit}>Submit</button>
-            </div>
-        );
-    }
+    if (state.loading) {return null;}
+    return (
+        <div>
+            <br />
+            <br />
+            <p>Add world to {props.campaign.name}</p>
+            <input type="text" name="name" placeholder='World Name' onChange={handleChange}/>
+            <input type="file" name="file" id="file" onChange={handleSelect}/>
+            <label htmlFor="file">{state.filename}</label>
+            <button onClick={handleSubmit}>Submit</button>
+            <br />
+            Draw click area below
+            <MapContainer center={[0, 0]}
+                        keyboard={false}
+                        zoom={-1}
+                        scrollWheelZoom={false}
+                        crs={CRS.Simple}
+                        minZoom={-1}
+                        maxZoom={-1}
+                        dragging={false}
+                        zoomControl={false}
+            >
+                <WorldLinkDrawer newWorldState={state} newWorldSetState={setState}/>
+                <ImageOverlay url={props.campaign.image}
+                              bounds={[[-1 * state.height, -1 * state.width], [state.height, state.width]]} />
+            </MapContainer>
+        </div>
+    );
 }
 
 export default NewWorld;

--- a/src/components/intel/World.js
+++ b/src/components/intel/World.js
@@ -1,9 +1,9 @@
 import React from "react";
 import { MapContainer, ImageOverlay } from 'react-leaflet';
+import { CRS } from "leaflet";
 
 import Pin from './Pin.js';
 import NewPin from './NewPin.js';
-import { CRS } from "leaflet";
 
 function World(props) {
     if (props.world == undefined) {return null;}

--- a/src/components/intel/WorldLinkDrawer.js
+++ b/src/components/intel/WorldLinkDrawer.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { CircleMarker, useMapEvents } from 'react-leaflet';
+
+function WorldLinkDrawer(props) {
+    const [state, setState] = useState({
+        newMarker: false,
+        centerLatLng: [0,0],
+        centerPx: [0,0],
+        radius: 0,
+        settingRadius: false
+    });
+
+    useMapEvents({
+        click: (event) => {
+            if (state.settingRadius) {
+                setState({
+                    ...state,
+                    settingRadius: false
+                });
+                props.newWorldSetState({
+                    ...props.newWorldState,
+                    centerLat: state.centerLatLng.lat,
+                    centerLng: state.centerLatLng.lng,
+                    radius: state.radius
+                });
+            } else {
+                setState({
+                    ...state,
+                    newMarker: true,
+                    centerLatLng: event.latlng,
+                    centerPx: event.containerPoint,
+                    settingRadius: true,
+                    radius: 0
+                });
+            }
+
+        },
+        mousemove: (event) => {
+            if (state.settingRadius) {
+                let radius = Math.hypot(event.containerPoint.x - state.centerPx.x, event.containerPoint.y - state.centerPx.y);
+                setState({
+                    ...state,
+                    radius: radius
+                });
+            }
+        }
+    });
+
+    if (state.newMarker === false) {
+        return null;
+    }
+
+    return (
+        <CircleMarker center={state.centerLatLng} radius={state.radius} />
+    );
+}
+
+export default WorldLinkDrawer;

--- a/static/Intel.sass
+++ b/static/Intel.sass
@@ -5,11 +5,6 @@ $secondary-txt-color: var(--secondary-txt-color)
 $primary-lnk-color: var(--primary-lnk-color)
 $secondary-lnk-color: var(--secondary-lnk-color)
 
-.campaign 
-  margin-left: auto
-  margin-right: auto
-  width: 80%
-
 .leaflet-container
   width: 100%
   height: 90vh


### PR DESCRIPTION
Requires backend pull request of the same name. Converted campaign image to another leaflet mapcontainer and used invisible circle markers to act as links to the worlds.

These circle markers need to be drawn when the world is created, so the map also gets shown in the add world form.