### PR TITLE
added ability for admins to edit campaigns

### DIFF
--- a/src/components/intel/Campaign.js
+++ b/src/components/intel/Campaign.js
@@ -49,7 +49,11 @@ function Campaign(props) {
             </MapContainer>
             <br />
             {props.Application.state.currentUser.role === "admin" ? // if user is admin
-                <Link to={`/campaigns/${props.campaign.name}/addworld`}>Add World</Link>
+                <div>
+                    <Link to={`/campaigns/${props.campaign.name}/addworld`}>Add World</Link>
+                    <br />
+                    <Link to={`/campaigns/${props.campaign.name}/update`}>Edit Campaign</Link>
+                </div>
             : // else
                 "" /* end if user is admin */}
         </div>

--- a/src/components/intel/CampaignSelector.js
+++ b/src/components/intel/CampaignSelector.js
@@ -9,6 +9,7 @@ import {
 } from 'react-router-dom';
 
 import Campaign from './Campaign';
+import CampaignUpdate from './CampaignUpdate';
 import World from './World';
 import NewWorld from './NewWorld';
 import Socket from '../../helper_functions/Socket';
@@ -124,6 +125,10 @@ function CampaignSelector(props) {
                                                                                     Application={state.Application}
                                                                                     campaign={state.activeCampaign}/>}
                                                                                     />
+                <Route exact path="/campaigns/:campaign/update" render={props => <CampaignUpdate {...props}
+                                                                                    Application={state.Application}
+                                                                                    campaign={state.activeCampaign}/>}
+                                                                                    />               
                 <Route exact path="/campaigns/:campaign/:world" render={props => <World {...props} 
                                                                                     Application={state.Application}
                                                                                     world={state.activeWorld} />}

--- a/src/components/intel/CampaignUpdate.js
+++ b/src/components/intel/CampaignUpdate.js
@@ -39,7 +39,7 @@ function CampaignUpdate(props) {
                 is_archived: state.is_archived,
             }));
             socket.send('campaign-update');
-            props.history.push(`/campaigns/${state.name}`);
+            props.history.push(`/`);
             swal("Success", "Campaign updated!", "success");
         } catch (error) {
             swal("Error", error.response.data, "error");

--- a/src/components/intel/CampaignUpdate.js
+++ b/src/components/intel/CampaignUpdate.js
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from "react";
+import swal from "sweetalert";
+
+import Socket from "../../helper_functions/Socket";
+
+const socket = new Socket();
+
+const axios = require("axios").default;
+
+function CampaignUpdate(props) {
+    const [state, setState] = useState({
+        name: props.campaign.name,
+        is_default: props.campaign.is_default,
+        is_archived: props.campaign.is_archived,
+    });
+
+    useEffect(() => {
+        socket.connect();
+        return () => {
+            socket.disconnect();
+        };
+    },[]);
+
+    const handleCheckChange = (event) => setState({
+        ...state,
+        [event.target.name]: event.target.checked
+    });
+
+    const handleChange = (event) => setState({
+        ...state,
+        [event.target.name]: event.target.value
+    });
+
+    const handleSubmit = async () => {
+        try {
+            await axios.patch(`/api/campaigns/${props.campaign.id}`, JSON.stringify({
+                name: state.name,
+                is_default: state.is_default,
+                is_archived: state.is_archived,
+            }));
+            socket.send('campaign-update');
+            props.history.push(`/campaigns/${state.name}`);
+            swal("Success", "Campaign updated!", "success");
+        } catch (error) {
+            swal("Error", error.response.data, "error");
+        }
+    };
+
+    return(
+        <div>
+            <div className="grid-2">
+                <p>Name:</p>
+                <input type="text" name="name" value={state.name} onChange={handleChange} />
+                <p>Is Archived:</p>
+                <input type="checkbox" name="is_archived" checked={state.is_archived} onChange={handleCheckChange }/>
+                <p>Is Default:</p>
+                <input type="checkbox" name="is_default" checked={state.is_default} onChange={handleCheckChange} />
+            </div>
+            <button onClick={handleSubmit}>Submit</button>
+            <img src={props.campaign.image}/>
+        </div>
+    );
+}
+
+export default CampaignUpdate;


### PR DESCRIPTION
There is an update to the backend that goes with this, I just pushed it directly to master

Allows admins to edit campaign name, archive status, and default status

Link to form exists below the campaign map, next to add world