### PR TITLE
Map fixes

### DIFF
--- a/src/SocketContext.js
+++ b/src/SocketContext.js
@@ -18,12 +18,20 @@ export class Socket {
     this.connection.emit(e);
   }
 
-  registerListener(name, callback) {
-    this.connection.on(name, callback);
+  registerListener(name, callback, options) {
+    if (options.once) {
+      this.connection.once(name, callback);
+    } else {
+      this.connection.on(name, callback);
+    }
   }
 
-  removeListener(name) {
-    this.connection.removeListener(name);
+  removeListener(name, options) {
+    if (options.callback) {
+      this.connection.off(name, options.callback);
+    } else {
+      this.connection.removeListener(name);
+    }
   }
 }
 
@@ -35,11 +43,12 @@ export const SocketContextProvider = (props) => {
   const send = useCallback((e) => socket.send(e), [socket]);
   const disconnect = useCallback(() => socket.disconnect(), [socket]);
   const registerListener = useCallback(
-    (name, callback) => socket.registerListener(name, callback),
+    (name, callback, options = {}) =>
+      socket.registerListener(name, callback, options),
     [socket]
   );
   const removeListener = useCallback(
-    (name) => socket.removeListener(name),
+    (name, options = {}) => socket.removeListener(name, options),
     [socket]
   );
 

--- a/src/SocketContext.js
+++ b/src/SocketContext.js
@@ -3,9 +3,11 @@ import React, { createContext, useCallback, useContext, useState } from "react";
 
 export class Socket {
   connect() {
-    this.connection = io.connect(`${window.location.hostname}`, {
-      reconnection: true,
-    });
+    if (this.connection === undefined || !this.connection.connected) {
+      this.connection = io.connect(`${window.location.hostname}`, {
+        reconnection: true,
+      });
+    }
   }
 
   disconnect() {

--- a/src/components/intel/PinDetails/index.js
+++ b/src/components/intel/PinDetails/index.js
@@ -23,7 +23,7 @@ const PinDetails = (props) => {
   /* CONTEXT */
   const { setAlert } = useAlertBarContext();
   const { user } = useSessionContext();
-  const { send } = useSocketContext();
+  const { send, registerListener } = useSocketContext();
 
   /* FORM HANDLING */
   useEffect(() => {
@@ -36,11 +36,12 @@ const PinDetails = (props) => {
     setLoading(true);
     try {
       await axios.delete(`/api/pins/${pin.id}`);
+      registerListener("campaign-update", () => setLoading(false), {
+        once: true,
+      });
       send("campaign-update");
     } catch (error) {
       setAlert(error.response.data, "error");
-    }
-    if (isMounted) {
       setLoading(false);
     }
   };

--- a/src/components/intel/PinForm/index.js
+++ b/src/components/intel/PinForm/index.js
@@ -1,4 +1,11 @@
-import { Button, CircularProgress, Grid, MenuItem, Select, Tooltip } from "@material-ui/core";
+import {
+  Button,
+  CircularProgress,
+  Grid,
+  MenuItem,
+  Select,
+  Tooltip,
+} from "@material-ui/core";
 import { Popup } from "react-leaflet";
 import React, { useEffect, useState } from "react";
 import useSocketContext from "SocketContext";
@@ -11,8 +18,6 @@ import { useCampaignContext } from "components/intel/Home";
 const PinForm = (props) => {
   /* PROPS */
   const { pin, handleCancel, marker, offset, coords } = props;
-
-  console.log(props);
 
   useEffect(() => {
     window.setTimeout(() => {
@@ -49,7 +54,7 @@ const PinForm = (props) => {
 
   /* CONTEXT */
   const { setAlert } = useAlertBarContext();
-  const { send } = useSocketContext();
+  const { send, registerListener } = useSocketContext();
   const { world } = useCampaignContext();
 
   /* FORM HANDLING */
@@ -111,12 +116,19 @@ const PinForm = (props) => {
       } else {
         await axios.post("/api/pins", payload);
       }
+      registerListener(
+        "campaign-update",
+        () => {
+          setLoading(false);
+          handleCancel();
+        },
+        { once: true }
+      );
       send("campaign-update");
-      handleCancel();
     } catch (error) {
       setAlert(error.response.data, "error");
+      setLoading(false);
     }
-    setLoading(false);
   };
 
   /* COMPONENT PROPS */


### PR DESCRIPTION
Added some functionality to the socket in order to have better performing map/pins.

- Connect will no longer reconnect unless it needs to.
- RegisterListener can take in an options object. Currently only used to specify if it is a one-time event listener.
- RemoveListener can take in an options object. Currently only used to specify a specific callback to remove.
- Creating/editing/deleting a pin utilizes the new RegisterListener options object to wait for the event before turning loading off.